### PR TITLE
Uglify modernization

### DIFF
--- a/lib/inline-assets.js
+++ b/lib/inline-assets.js
@@ -31,7 +31,7 @@ var _        = require("lodash");
 var datauri  = require("datauri");
 var htmlmin  = require("html-minifier").minify;
 var CSSO     = require("csso");
-var uglifyjs = require("uglify-js");
+var uglifyjs = require("uglify-es");
 
 /*  generate regular expression for an XML simple tag  */
 var reXMLTagSimple = function (name) {
@@ -124,7 +124,10 @@ var inlineAssetsForJS = function (basename, filename, content, options) {
     if (options.jsmin) {
         var len2 = content.length;
         verbose(options, "minifying", "JS", filename, len2, -1);
-        content = uglifyjs.minify(content, { fromString: true, mangle: false });
+        content = uglifyjs.minify(content, { mangle: false });
+		if(content.error){
+			throw content.error;
+		}
         verbose(options, "minifying", "JS", filename, len2, content.length);
     }
     verbose(options, "expanded", "JS", filename, len, content.length);

--- a/lib/inline-assets.js
+++ b/lib/inline-assets.js
@@ -124,13 +124,15 @@ var inlineAssetsForJS = function (basename, filename, content, options) {
     if (options.jsmin) {
         var len2 = content.length;
         verbose(options, "minifying", "JS", filename, len2, -1);
-        content = uglifyjs.minify(content, { mangle: false });
-		if(content.error){
-			throw content.error;
+        var result = uglifyjs.minify(content, { mangle: false });
+		if(result.error){
+			throw result.error;
 		}
+		content = result.code;
         verbose(options, "minifying", "JS", filename, len2, content.length);
     }
     verbose(options, "expanded", "JS", filename, len, content.length);
+	
     return content;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,48 +1,55 @@
 {
-    "name":        "inline-assets",
-    "homepage":    "http://github.com/rse/node-inline-assets",
+    "name": "inline-assets",
+    "homepage": "http://github.com/rse/node-inline-assets",
     "description": "Inline External Assets of HTML/CSS Files",
-    "version":     "1.4.3",
-    "license":     "MIT",
+    "version": "1.4.3",
+    "license": "MIT",
     "author": {
-        "name":    "Dr. Ralf S. Engelschall",
-        "email":   "rse@engelschall.com",
-        "url":     "http://engelschall.com"
+        "name": "Dr. Ralf S. Engelschall",
+        "email": "rse@engelschall.com",
+        "url": "http://engelschall.com"
     },
     "keywords": [
-        "inline", "asset", "html", "css", "js", "data", "url", "uri"
+        "inline",
+        "asset",
+        "html",
+        "css",
+        "js",
+        "data",
+        "url",
+        "uri"
     ],
     "repository": {
         "type": "git",
-        "url":  "git://github.com/rse/node-inline-assets.git"
+        "url": "git://github.com/rse/node-inline-assets.git"
     },
     "bugs": {
-        "url":  "http://github.com/rse/node-inline-assets/issues"
+        "url": "http://github.com/rse/node-inline-assets/issues"
     },
     "main": "./lib/inline-assets.js",
     "bin": {
         "inline-assets": "./bin/inline-assets.js"
     },
     "devDependencies": {
-        "grunt":                "1.0.4",
-        "grunt-cli":            "1.3.2",
+        "grunt": "1.0.4",
+        "grunt-cli": "1.3.2",
         "grunt-contrib-jshint": "2.1.0",
-        "grunt-contrib-clean":  "2.0.0",
-        "grunt-eslint":         "21.1.0"
+        "grunt-contrib-clean": "2.0.0",
+        "grunt-eslint": "21.1.0"
     },
-    "dependencies" : {
-        "package":              "1.0.1",
-        "lodash":               "4.17.11",
-        "datauri":              "2.0.0",
-        "html-minifier":        "4.0.0",
-        "csso":                 "3.5.1",
-        "uglify-js":            "3.6.0",
-        "chalk":                "2.4.2",
-        "pretty-bytes":         "5.2.0",
-        "sprintfjs":            "1.2.14",
-        "dashdash":             "1.14.1"
+    "dependencies": {
+        "chalk": "2.4.2",
+        "csso": "3.5.1",
+        "dashdash": "1.14.1",
+        "datauri": "2.0.0",
+        "html-minifier": "4.0.0",
+        "lodash": "4.17.11",
+        "package": "1.0.1",
+        "pretty-bytes": "5.2.0",
+        "sprintfjs": "1.2.14",
+        "uglify-es": "^3.3.9"
     },
     "engines": {
-        "node":                 ">=8.0.0"
+        "node": ">=8.0.0"
     }
 }


### PR DESCRIPTION
* uglify-js replaced with uglify-es in order to support ES6+
* fixed problem with handling results from minify() caused by uglify-js/es@3 API changes
