### PR TITLE
Add support for inlining inline style attribute assets

### DIFF
--- a/lib/inline-assets.js
+++ b/lib/inline-assets.js
@@ -172,7 +172,7 @@ var inlineAssetsForCSS = function (basename, filename, content, options) {
             if (processAsset(options, fn)) {
                 var data = fs.readFileSync(fn, { encoding: null });
                 data = inlineAssetsForData(filename, fn, data, options);
-                stmt = "url(\"" + data + "\")";
+                stmt = "url('" + data + "')";
                 if (fm)
                     stmt += " format(\"" + fm + "\")";
                 if (epilog)
@@ -259,6 +259,15 @@ var inlineAssetsForHTML = function (basename, filename, content, options) {
             }
         }
         return tag;
+    });
+    //inline images for inline style attribute
+    content = content.replace(reXMLTagSimple("[a-zA-Z]*"), function (tag, name, attrs) {
+      var attr = attrOfTag(attrs);
+      if (typeof attr.style === "string" && attr.style.match(/\.(?:png|gif|jpe?g|svg)/gi)) {
+        attr.style = inlineAssetsForCSS(basename, filename, attr.style, {pattern: options.pattern});
+        tag = genXMLTag(name, attr, "");
+      }
+      return tag;
     });
     if (options.htmlmin) {
         var len2 = content.length;

--- a/sample/src/sample1.html
+++ b/sample/src/sample1.html
@@ -9,5 +9,6 @@
     <body>
         <h1>sample1</h1>
         <img src="sample1.svg"/>
+        <div style="width:50px;height:50px;border:1px solid black;background-image:url(sample1.svg)"/></div>
     </body>
 </html>


### PR DESCRIPTION
Needed the following style attribute to inline the background-image rule:
```<div style="width:50px;height:50px;border:1px solid black;background-image:url(sample1.svg)"/></div>```