### PR TITLE
Update lodash to 4.17.21.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies" : {
         "package":              "1.0.1",
-        "lodash":               "4.17.20",
+        "lodash":               "4.17.21",
         "datauri":              "3.0.0",
         "html-minifier":        "4.0.0",
         "csso":                 "4.2.0",


### PR DESCRIPTION
Picks up fix to https://app.snyk.io/vuln/SNYK-JS-LODASH-1040724, which
is reported by `npm audit`.

Thank you for writing this tool!